### PR TITLE
Fix identify crashing

### DIFF
--- a/src/devices/accessory.ts
+++ b/src/devices/accessory.ts
@@ -47,7 +47,9 @@ export class AccessoryParser {
       accessory.reachable = true;
       accessory.on('identify', (paired: any, callback: any) => {
         this.platform.log.debug(accessory.displayName + ' Identify!!!');
-        callback();
+        if (callback) { // callback may not exist
+          callback();
+        }
       });
 
       return accessory;


### PR DESCRIPTION
Ignore the typo in the branch name, it's meant to say `fix-identify-crash` 😛 

When identifying accessories, the Home app would sometimes freak out because the callback was never finished (therefore the identify command hung).  This fixes that!