### PR TITLE
Dynamic accessory removal/creation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -100,7 +100,7 @@ export class WideQ {
     });
     await Promise.all(promises);
 
-    this.unregisterPlatformAccessories(accessoriesToRemove.map(this.AccessoryUtil.getByUUID));
+    this.unregisterPlatformAccessories(accessoriesToRemove.map(this.AccessoryUtil.getByUUID.bind(this.AccessoryUtil)));
 
     await this.runMonitoring();
   }


### PR DESCRIPTION
This solves the "TODO remove accessories only if needed".

Rather than removing and re-creating all accessories on each run, this will only remove accessories when they're removed from the configuration, and only add when it was not yet already registered.

The best way to find the accessory ID was, as best I could tell, was through `ParseUtil.getByModel(device.device.type).getAccessoryUUID(d.id);` – there's likely a better way?  This works, but let me know if there are potential improvements!